### PR TITLE
Fix title highlighting issue in docs

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -85,5 +85,5 @@ dl.py.property, dl.py.attribute, dl.py.method, dl.py.function {
 
 /* Workaround for highlighting issue in Furo */
 [role=main] .highlighted {
-    background-color: transparent !important;
+    -webkit-text-fill-color: initial !important;
 }

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -82,3 +82,8 @@ dl.py.property, dl.py.attribute, dl.py.method, dl.py.function {
     color: var(--color-brand-content);
     font-style: italic;
 }
+
+/* Workaround for highlighting issue in Furo */
+[role=main] .highlighted {
+    background-color: transparent !important;
+}


### PR DESCRIPTION
[Issue](https://github.com/IfcOpenShell/IfcOpenShell/issues/4807)

The `.highlighted` class in Furo added a background color, but heading titles had the `-webkit-text-fill-color` set to `transparent` which was causing the text to appear invisible.
Now, `.highlighted` class forces texts to not have transparent fill color.